### PR TITLE
Export sentinel package errors

### DIFF
--- a/branca.go
+++ b/branca.go
@@ -122,7 +122,7 @@ func (b *Branca) DecodeToString(data string) (string, error) {
 	}
 	base62, err := basex.NewEncoding(base62)
 	if err != nil {
-		return "", ErrInvalidToken
+		return "", fmt.Errorf("%v", err)
 	}
 	token, err := base62.Decode(data)
 	if err != nil {

--- a/branca.go
+++ b/branca.go
@@ -118,7 +118,7 @@ func (b *Branca) EncodeToString(data string) (string, error) {
 // DecodeToString decodes the data.
 func (b *Branca) DecodeToString(data string) (string, error) {
 	if len(data) < 62 {
-		return "", ErrInvalidToken
+		return "", fmt.Errorf("%w: length is less than 62", ErrInvalidToken)
 	}
 	base62, err := basex.NewEncoding(base62)
 	if err != nil {
@@ -135,7 +135,7 @@ func (b *Branca) DecodeToString(data string) (string, error) {
 	nonce := header[5:]
 
 	if tokenversion != version {
-		return "", ErrInvalidTokenVersion
+		return "", fmt.Errorf("%w: got %#X but expected %#X", ErrInvalidTokenVersion, tokenversion, version)
 	}
 
 	key := bytes.NewBufferString(b.Key).Bytes()

--- a/branca_test.go
+++ b/branca_test.go
@@ -188,7 +188,8 @@ func TestExpiredTokenError(t *testing.T) {
 	time.Sleep(ttl * 3)
 	// ...and decode the token again that is expired by now.
 	_, decErr := b.DecodeToString(token)
-	if !errors.Is(decErr, ErrExpiredToken) {
+	var errExpiredToken *ErrExpiredToken
+	if !errors.As(decErr, &errExpiredToken) {
 		t.Errorf("%v", decErr)
 	}
 }


### PR DESCRIPTION
Before this PR, the only way to explicitly check which error occurred was to test against the actual string error message.
This is a anti-pattern and comes with a high risk of breaking when the value gets changed in the library.

To allow to check against the errors, this PR exports the types so they can be tested using the [`errors.Is(error, error)` function from Go's `errors` package][doc-errors.is].

A suggestion to implement this change was already requested in https://github.com/hako/branca/issues/5#issuecomment-416915978, but at the time of this commit a PR has not been submitted yet.

This PR also includes 4 new tests to ensure the exported error types can be checked using `errors.Is(error, error)`.
The execution of the tests is way slower because the new `TestExpiredTokenError` test makes use of the
`time.Sleep(time.Duration)` function with a value of 3 seconds in order to ensure the TTL of the token is expired, but unfortunately there is no other way to test this scenario.

[doc-errors.is]: https://pkg.go.dev/errors?tab=doc#Is