### PR TITLE
Fix index specification of slice

### DIFF
--- a/branca.go
+++ b/branca.go
@@ -128,7 +128,7 @@ func (b *Branca) DecodeToString(data string) (string, error) {
 	if err != nil {
 		return "", ErrInvalidToken
 	}
-	header := token[0:29]
+	header := token[:29]
 	ciphertext := token[29:]
 	tokenversion := header[0]
 	timestamp := binary.BigEndian.Uint32(header[1:5])


### PR DESCRIPTION
Hi,
Fixed index specification of slice.
token[0:29] and token[:29] have the same meaning,
The code one line down was token[29:], so
I thought it would be easier to understand if they were unified.